### PR TITLE
Make CI use dev images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,11 +54,13 @@ jobs:
           name: Build Driver
           command: |
             source ${INIT_ENV}
+            export ROS_PARALLEL_JOBS='-j1 -l1' # Try to reduce memory consumption on build
             build-wrapper-linux-x86-64 --out-dir /opt/carma/bw-output bash make_with_coverage.bash -m -e /opt/carma/ -o ./coverage_reports/gcov
       - run:
           name: Run C++ Tests
           command: |
             source ${INIT_ENV}
+            export ROS_PARALLEL_JOBS='-j1 -l1' # Try to reduce memory consumption on build
             bash make_with_coverage.bash -t -e /opt/carma/ -o ./coverage_reports/gcov
       # Run SonarCloud analysis
       # PR Branchs and number extracted from Circle variables and github api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           name: Pull Deps
           command: |
             source ${INIT_ENV}
-            ./src/CARMAPlatform/docker/checkout.sh -r ${PWD}
+            ./src/carma-simulation/docker/checkout.sh -r ${PWD}
       - run:
           name: Build Driver
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,12 @@ jobs:
             mkdir carma-simulation
       - checkout:
           path: src/carma-simulation
+      - run: 
+          name: Pull Deps
+          command: |
+            source ${INIT_ENV}
+            ./src/CARMAPlatform/docker/checkout.sh -r ${PWD}
+            cd ${PWD}
       - run:
           name: Build Driver
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
           command: |
             source ${INIT_ENV}
             ./src/CARMAPlatform/docker/checkout.sh -r ${PWD}
-            cd ${PWD}
       - run:
           name: Build Driver
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastol/carma-base:3.7.0
+      - image: usdotfhwastoldev/carma-base:develop
         user: carma
         environment:
           TERM: xterm # use xterm to get full display output from build

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastol/carma-base:3.6.0 as deps
+FROM usdotfhwastoldev/carma-base:develop as deps
 
 # Install remaining package deps
 RUN mkdir ~/src

--- a/docker/checkout.sh
+++ b/docker/checkout.sh
@@ -42,7 +42,3 @@ else
       git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ${dir}/src/carma-msgs --branch develop --depth 1
       git clone https://github.com/usdot-fhwa-stol/carma-utils.git ${dir}/src/carma-utils --branch develop --depth 1
 fi
-
-# Required to build the ackermann_msgs and carla_msgs.
-git clone https://github.com/ros-drivers/ackermann_msgs.git ${dir}/src/ackermann_msgs --branch master --depth 1
-git clone https://github.com/carla-simulator/ros-carla-msgs.git ${dir}/src/carla_msgs --branch master --depth 1

--- a/docker/checkout.sh
+++ b/docker/checkout.sh
@@ -36,11 +36,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ "$BRANCH" = "develop" ]]; then
-      git clone https://github.com/usdot-fhwa-stol/CARMAMsgs.git ~/src/CARMAMsgs --branch $BRANCH --depth 1
-      git clone https://github.com/usdot-fhwa-stol/CARMAUtils.git ~/src/CARMAUtils --branch $BRANCH --depth 1    
+      git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ~/src/carma-msgs --branch $BRANCH --depth 1
+      git clone https://github.com/usdot-fhwa-stol/carma-utils.git ~/src/carma-utils --branch $BRANCH --depth 1    
 else
-      git clone https://github.com/usdot-fhwa-stol/CARMAMsgs.git ${dir}/src/CARMAMsgs --branch CARMAMsgs_1.3.0 --depth 1
-      git clone https://github.com/usdot-fhwa-stol/CARMAUtils.git ${dir}/src/CARMAUtils --branch CARMAUtils_1.3.0 --depth 1
+      git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ${dir}/src/carma-msgs --branch develop --depth 1
+      git clone https://github.com/usdot-fhwa-stol/carma-utils.git ${dir}/src/carma-utils --branch develop --depth 1
 fi
 
 # Required to build the ackermann_msgs and carla_msgs.


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Make circle CI use the dev images so that it is always building off the develop branch of carma-base. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/723
## Motivation and Context
Better CI
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running CI on this PR
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.