### PR TITLE
Migrate logic for v2x messaging from platform to infrastructure

### DIFF
--- a/co-simulation/NOTICE-THIRD-PARTY.md
+++ b/co-simulation/NOTICE-THIRD-PARTY.md
@@ -245,6 +245,14 @@ Logback Core Module (1.2.3)
  * Source: https://github.com/ceki/logback/logback-core
 
 
+mosaic-carma-utils (22.1-SNAPSHOT)
+
+ * License: Eclipse Public License - v 2.0
+ * Maven artifact: `gov.dot.fhwa.saxton:mosaic-carma-utils:22.1-SNAPSHOT`
+ * Project: not available
+ * Source: https://github.com/eclipse/mosaic/lib/mosaic-carma-utils
+
+
 org.leadpony.justify (1.1.0)
 
  * License: The Apache Software License, Version 2.0

--- a/co-simulation/fed/mosaic-carma/pom.xml
+++ b/co-simulation/fed/mosaic-carma/pom.xml
@@ -26,6 +26,11 @@
       <version>${mosaic.version}</version>
     </dependency>
     <dependency>
+        <groupId>gov.dot.fhwa.saxton</groupId>
+        <artifactId>mosaic-carma-utils</artifactId>
+        <version>${mosaic.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.9</version>

--- a/co-simulation/fed/mosaic-carma/src/main/java/org/eclipse/mosaic/fed/carma/ambassador/CarmaInstanceManager.java
+++ b/co-simulation/fed/mosaic-carma/src/main/java/org/eclipse/mosaic/fed/carma/ambassador/CarmaInstanceManager.java
@@ -16,14 +16,7 @@
 
 package org.eclipse.mosaic.fed.carma.ambassador;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.SocketException;
-import java.net.UnknownHostException;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.eclipse.mosaic.fed.carma.ambassador.CarmaRegistrationMessage;
+import gov.dot.fhwa.saxton.CarmaV2xMessage;
 import org.eclipse.mosaic.interactions.communication.V2xMessageTransmission;
 import org.eclipse.mosaic.interactions.traffic.VehicleUpdates;
 import org.eclipse.mosaic.lib.enums.AdHocChannel;
@@ -32,6 +25,12 @@ import org.eclipse.mosaic.lib.objects.v2x.ExternalV2xContent;
 import org.eclipse.mosaic.lib.objects.v2x.ExternalV2xMessage;
 import org.eclipse.mosaic.lib.objects.v2x.MessageRouting;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Session management class for CARMA Platform instances communicating with MOSAIC

--- a/co-simulation/fed/mosaic-carma/src/main/java/org/eclipse/mosaic/fed/carma/ambassador/CarmaMessageAmbassador.java
+++ b/co-simulation/fed/mosaic-carma/src/main/java/org/eclipse/mosaic/fed/carma/ambassador/CarmaMessageAmbassador.java
@@ -13,41 +13,36 @@
 
 package org.eclipse.mosaic.fed.carma.ambassador;
 
+import gov.dot.fhwa.saxton.CarmaV2xMessage;
+import gov.dot.fhwa.saxton.CarmaV2xMessageReceiver;
+import org.eclipse.mosaic.fed.application.ambassador.SimulationKernel;
+import org.eclipse.mosaic.fed.carma.configuration.CarmaConfiguration;
+import org.eclipse.mosaic.fed.carma.configuration.CarmaVehicleConfiguration;
+import org.eclipse.mosaic.interactions.application.CarmaV2xMessageReception;
+import org.eclipse.mosaic.interactions.application.ExternalMessage;
 import org.eclipse.mosaic.interactions.communication.V2xMessageReception;
 import org.eclipse.mosaic.interactions.communication.V2xMessageTransmission;
+import org.eclipse.mosaic.interactions.traffic.VehicleUpdates;
+import org.eclipse.mosaic.interactions.vehicle.VehicleFederateAssignment;
+import org.eclipse.mosaic.lib.enums.DriveDirection;
 import org.eclipse.mosaic.lib.misc.Tuple;
-import org.eclipse.mosaic.lib.objects.addressing.DestinationAddressContainer;
 import org.eclipse.mosaic.lib.objects.v2x.ExternalV2xMessage;
-import org.eclipse.mosaic.lib.objects.v2x.MessageRouting;
 import org.eclipse.mosaic.lib.objects.v2x.V2xMessage;
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture;
+import org.eclipse.mosaic.lib.util.objects.ObjectInstantiation;
 import org.eclipse.mosaic.rti.TIME;
 import org.eclipse.mosaic.rti.api.AbstractFederateAmbassador;
 import org.eclipse.mosaic.rti.api.IllegalValueException;
+import org.eclipse.mosaic.rti.api.Interaction;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 import org.eclipse.mosaic.rti.api.parameters.AmbassadorParameter;
 
-import org.eclipse.mosaic.fed.carma.ambassador.CarmaRegistrationMessage;
-
-import org.eclipse.mosaic.fed.carma.configuration.CarmaConfiguration;
-import org.eclipse.mosaic.fed.application.ambassador.SimulationKernel;
-import org.eclipse.mosaic.fed.carma.configuration.CarmaVehicleConfiguration;
-
+import javax.xml.bind.DatatypeConverter;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-
-import org.eclipse.mosaic.rti.api.Interaction;
-import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
-import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture;
-import org.eclipse.mosaic.lib.util.objects.ObjectInstantiation;
-import org.eclipse.mosaic.interactions.application.CarmaV2xMessageReception;
-import org.eclipse.mosaic.interactions.application.ExternalMessage;
-import org.eclipse.mosaic.interactions.traffic.VehicleUpdates;
-import org.eclipse.mosaic.interactions.vehicle.VehicleFederateAssignment;
-import org.eclipse.mosaic.lib.enums.DriveDirection;
-
-import javax.xml.bind.DatatypeConverter;
 
 /**
  * Implementation of a {@link AbstractFederateAmbassador} for CARMA message

--- a/co-simulation/fed/mosaic-infrastructure/pom.xml
+++ b/co-simulation/fed/mosaic-infrastructure/pom.xml
@@ -26,6 +26,11 @@
       <version>${mosaic.version}</version>
     </dependency>
     <dependency>
+        <groupId>gov.dot.fhwa.saxton</groupId>
+        <artifactId>mosaic-carma-utils</artifactId>
+        <version>${mosaic.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.mosaic</groupId>
       <artifactId>mosaic-interactions</artifactId>
       <version>${mosaic.version}</version>

--- a/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureMessageAmbassador.java
+++ b/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureMessageAmbassador.java
@@ -60,10 +60,8 @@ public class InfrastructureMessageAmbassador extends AbstractFederateAmbassador 
 
     private InfrastructureRegistrationReceiver infrastructureRegistrationReceiver;
     private Thread registrationRxBackgroundThread;
-    private InfrastructureTimeMessageReceiver infrastructureTimeMessageReceiver;
-    private Thread v2xTimeRxBackgroundThread;
 
-    private CarmaV2xMessageReceiver v2xMessageReceiver = new CarmaV2xMessageReceiver(1517);
+    private CarmaV2xMessageReceiver v2xMessageReceiver = new CarmaV2xMessageReceiver(1515);
     private Thread v2xMessageBackgroundThread;
 
     private InfrastructureInstanceManager infrastructureInstanceManager = new InfrastructureInstanceManager();
@@ -109,12 +107,6 @@ public class InfrastructureMessageAmbassador extends AbstractFederateAmbassador 
     public void initialize(long startTime, long endTime) throws InternalFederateException {
         super.initialize(startTime, endTime);
         currentSimulationTime = startTime;
-        try {
-            rti.requestAdvanceTime(currentSimulationTime, 0, (byte) 1);
-        } catch (IllegalValueException e) {
-            log.error("Error during advanceTime request", e);
-            throw new InternalFederateException(e);
-        }
 
         infrastructureRegistrationReceiver = new InfrastructureRegistrationReceiver();
         infrastructureRegistrationReceiver.init();
@@ -126,6 +118,13 @@ public class InfrastructureMessageAmbassador extends AbstractFederateAmbassador 
         v2xMessageReceiver.init();
         v2xMessageBackgroundThread = new Thread(v2xMessageReceiver);
         v2xMessageBackgroundThread.start();
+
+        try {
+            rti.requestAdvanceTime(currentSimulationTime, 0, (byte) 1);
+        } catch (IllegalValueException e) {
+            log.error("Error during advanceTime request", e);
+            throw new InternalFederateException(e);
+        }
     }
 
     /**
@@ -317,5 +316,13 @@ public class InfrastructureMessageAmbassador extends AbstractFederateAmbassador 
     @Override
     public boolean isTimeRegulating() {
         return false;
+    }
+
+    /**
+     * Test helper function to cleanup sockets and threads.
+     */
+    protected void close() {
+        v2xMessageReceiver.stop();
+        infrastructureRegistrationReceiver.stop();
     }
 }

--- a/co-simulation/fed/mosaic-infrastructure/src/test/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureMessageAmbassadorTest.java
+++ b/co-simulation/fed/mosaic-infrastructure/src/test/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureMessageAmbassadorTest.java
@@ -16,27 +16,24 @@
 
 package org.eclipse.mosaic.fed.infrastructure.ambassador;
 
-import org.junit.Test;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.eclipse.mosaic.lib.util.junit.TestFileRule;
 import org.eclipse.mosaic.rti.TIME;
 import org.eclipse.mosaic.rti.api.RtiAmbassador;
 import org.eclipse.mosaic.rti.api.parameters.AmbassadorParameter;
 import org.eclipse.mosaic.rti.api.parameters.FederateDescriptor;
 import org.eclipse.mosaic.rti.config.CLocalHost;
-
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link InfrastructureMessageAmbassador}.
@@ -77,6 +74,11 @@ public class InfrastructureMessageAmbassadorTest {
         ambassador.setRtiAmbassador(rtiMock);
 
         ambassador.setFederateDescriptor(handleMock);
+    }
+
+    @After
+    public void teardown() throws IOException {
+        ambassador.close();
     }
 
     @Test

--- a/co-simulation/lib/mosaic-carma-utils/pom.xml
+++ b/co-simulation/lib/mosaic-carma-utils/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.mosaic</groupId>
+        <artifactId>mosaic-parent</artifactId>
+        <version>22.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>gov.dot.fhwa.saxton</groupId>
+    <artifactId>mosaic-carma-utils</artifactId>
+</project>

--- a/co-simulation/lib/mosaic-carma-utils/pom.xml
+++ b/co-simulation/lib/mosaic-carma-utils/pom.xml
@@ -12,4 +12,42 @@
 
     <groupId>gov.dot.fhwa.saxton</groupId>
     <artifactId>mosaic-carma-utils</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mosaic</groupId>
+            <artifactId>mosaic-rti-api</artifactId>
+            <version>${mosaic.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.mosaic</groupId>
+            <artifactId>mosaic-objects</artifactId>
+            <version>${mosaic.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.mosaic</groupId>
+            <artifactId>mosaic-interactions</artifactId>
+            <version>${mosaic.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.mosaic</groupId>
+            <artifactId>mosaic-utils</artifactId>
+            <version>${mosaic.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.mosaic</groupId>
+            <artifactId>mosaic-geomath</artifactId>
+            <version>${mosaic.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/co-simulation/lib/mosaic-carma-utils/src/main/java/gov/dot/fhwa/saxton/CarmaV2xMessage.java
+++ b/co-simulation/lib/mosaic-carma-utils/src/main/java/gov/dot/fhwa/saxton/CarmaV2xMessage.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package org.eclipse.mosaic.fed.carma.ambassador;
+package gov.dot.fhwa.saxton;
 
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;

--- a/co-simulation/lib/mosaic-carma-utils/src/main/java/gov/dot/fhwa/saxton/CarmaV2xMessageReceiver.java
+++ b/co-simulation/lib/mosaic-carma-utils/src/main/java/gov/dot/fhwa/saxton/CarmaV2xMessageReceiver.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package org.eclipse.mosaic.fed.carma.ambassador;
+package gov.dot.fhwa.saxton;
 
 import org.eclipse.mosaic.lib.misc.Tuple;
 
@@ -38,9 +38,30 @@ public class CarmaV2xMessageReceiver implements Runnable {
 
     private Queue<Tuple<InetAddress, CarmaV2xMessage>> rxQueue = new LinkedList<>();
     private DatagramSocket listenSocket = null;
-    private static final int listenPort = 1516;
+    private int listenPort;
     private boolean running = true;
     private static final int UDP_MTU = 1535;
+
+    /**
+     * Default constructor added to preserve prior behavior after refactor into new package for re-use in Infrastructure
+     * Ambassador.
+     *
+     * Assumes a desired listen port of 1516.
+     */
+    public CarmaV2xMessageReceiver() {
+        this.listenPort = 1516;
+    }
+
+    /**
+     * Recommended constructor for CarmaV2XMessageReceiver.
+     *
+     * @param listenPort The host port that should be used to bind a UDP socket for receiving V2X message transmission
+     *                   events from connected CARMA software instances. An exception will be thrown in init() if this
+     *                   port is unavailable or socket binding fails for other reasons.
+     */
+    public CarmaV2xMessageReceiver(int listenPort) {
+        this.listenPort = listenPort;
+    }
 
     /**
      * Initialize the listen socket for messages from the CARMA Platform NS-3 Adapter

--- a/co-simulation/pom.xml
+++ b/co-simulation/pom.xml
@@ -80,6 +80,7 @@
         <module>app/tutorials/traffic-light-communication</module>
         <module>app/tutorials/weather-warning</module>
         <module>app/tutorials/external-communication</module>
+        <module>lib/mosaic-carma-utils</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Refactored existing logic into new maven module to re-use for infrastructure ambassador

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Migrating the v2x-message reception logic into a shared library so it can be easily incorporated into the infrastructure ambassador without code duplication.

## How Has This Been Tested?

Hasn't been tested yet, original module wasn't unit tested so I'll write some tonight but wanted to get this review out before COB.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.