### PR TITLE
Fixed Infrastructure Time message to use timestep in milliseconds

### DIFF
--- a/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureMessageAmbassador.java
+++ b/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureMessageAmbassador.java
@@ -228,7 +228,7 @@ public class InfrastructureMessageAmbassador extends AbstractFederateAmbassador 
      * time advance to the federate. Any unprocessed interactions are forwarded to
      * the federate using the processInteraction method before this call is made.
      *
-     * @param time The timestamp indicating the time to which the federate can
+     * @param time The timestamp (in nanoseconds) indicating the time to which the federate can
      *             advance its local time.
      */
     @Override
@@ -261,7 +261,8 @@ public class InfrastructureMessageAmbassador extends AbstractFederateAmbassador 
             timeSyncSeq += 1;
             InfrastructureTimeMessage timeSyncMessage = new InfrastructureTimeMessage();
             timeSyncMessage.setSeq(timeSyncSeq);
-            timeSyncMessage.setTimestep(currentSimulationTime);
+            // nanoseconds to milliseconds for InfrastructureTimeMessage
+            timeSyncMessage.setTimestep(currentSimulationTime/1000000);
             infrastructureTimeInterface.onTimeStepUpdate(timeSyncMessage);
 
             // TODO: Handle any queued V2X message receiver's received messages

--- a/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureTimeMessage.java
+++ b/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureTimeMessage.java
@@ -25,7 +25,9 @@ import java.nio.charset.StandardCharsets;
  * 
  */
 public class InfrastructureTimeMessage {
+    // Timestamp in milliseconds
     private long timestep;
+    // Sequence number for time message
     private int seq;
 
     public InfrastructureTimeMessage() {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Updated infrastructure time message to use millisecond timestep instead of nanosecond time step since that is what V2X-Hub and CARMA-Streets expect and we do not do any nanosecond level logic on infrastructure.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix bugs related to V2X-Hub/CARMA Streets Time Synchronization
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.