### PR TITLE
Fix/amf parser error

### DIFF
--- a/co-simulation/lib/mosaic-carma-utils/src/main/java/gov/dot/fhwa/saxton/CarmaV2xMessage.java
+++ b/co-simulation/lib/mosaic-carma-utils/src/main/java/gov/dot/fhwa/saxton/CarmaV2xMessage.java
@@ -18,6 +18,8 @@ package gov.dot.fhwa.saxton;
 
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.regex.Pattern;
 
 /**
  * Message to be sent or received by the CARMA Platform NS-3 Adapater interface
@@ -122,7 +124,16 @@ public class CarmaV2xMessage {
      */
     private void parseV2xMessage(byte[] buf)  {
         String msg = new String(buf, StandardCharsets.UTF_8);
-        String[] msgParts = msg.split("=");
+
+        // Modeled after Stackoverflow answer by user Eritrean: https://stackoverflow.com/users/5176992/eritrean
+        // On Question: https://stackoverflow.com/questions/61029164/how-to-split-string-by-comma-and-newline-n-in-java
+        // Asked by user: https://stackoverflow.com/users/12315939/kopite1905
+        // Used under CC BY-SA 4.0 license: https://creativecommons.org/licenses/by-sa/4.0/
+        String[] msgParts = Pattern.compile("\\R")
+                .splitAsStream(msg)
+                .map(s -> s.split("="))
+                .flatMap(Arrays::stream)
+                .toArray(String[]::new);
         
         for (int i = 0; i < msgParts.length; i++) {
             if (msgParts[i].equals("Version")) {

--- a/co-simulation/lib/mosaic-carma-utils/src/test/java/gov/dot/fhwa/saxton/CarmaV2xMessageTest.java
+++ b/co-simulation/lib/mosaic-carma-utils/src/test/java/gov/dot/fhwa/saxton/CarmaV2xMessageTest.java
@@ -1,0 +1,32 @@
+package gov.dot.fhwa.saxton;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class CarmaV2xMessageTest {
+
+    private final String sampleMessage = "Version=0.7\n" +
+"Type=BSM\n" +
+"PSID=0020\n" +
+"Priority=6\n" +
+"TxMode=ALT\n" +
+"TxChannel=172\n" +
+"TxInterval=0\n" +
+"DeliveryStart=\n" +
+"DeliveryStop=\n" +
+"Signature=False\n" +
+"Encryption=False\n" +
+"Payload=00142500400000000f0e35a4e900eb49d20000007fffffff8ffff080fdfa1fa1007fff8000960fa0\n";
+
+    @Before
+    public void setUp() throws Exception {
+        //manager = new InfrastructureInstanceManager();
+        //registration = mock(InfrastructureRegistrationMessage.class);
+    }
+
+    @Test
+    public void testCarmaV2xMessageParse() {
+        CarmaV2xMessage test = new CarmaV2xMessage(sampleMessage.getBytes());
+    }
+
+}

--- a/co-simulation/lib/mosaic-carma-utils/src/test/java/gov/dot/fhwa/saxton/CarmaV2xMessageTest.java
+++ b/co-simulation/lib/mosaic-carma-utils/src/test/java/gov/dot/fhwa/saxton/CarmaV2xMessageTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2019-2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package gov.dot.fhwa.saxton;
 
 import org.junit.Before;
@@ -5,28 +21,28 @@ import org.junit.Test;
 
 public class CarmaV2xMessageTest {
 
-    private final String sampleMessage = "Version=0.7\n" +
-"Type=BSM\n" +
-"PSID=0020\n" +
-"Priority=6\n" +
-"TxMode=ALT\n" +
-"TxChannel=172\n" +
-"TxInterval=0\n" +
-"DeliveryStart=\n" +
-"DeliveryStop=\n" +
-"Signature=False\n" +
-"Encryption=False\n" +
-"Payload=00142500400000000f0e35a4e900eb49d20000007fffffff8ffff080fdfa1fa1007fff8000960fa0\n";
+    private final String sampleMessage =
+            "Version=0.7\n" +
+            "Type=BSM\n" +
+            "PSID=0020\n" +
+            "Priority=6\n" +
+            "TxMode=ALT\n" +
+            "TxChannel=172\n" +
+            "TxInterval=0\n" +
+            "DeliveryStart=\n" +
+            "DeliveryStop=\n" +
+            "Signature=False\n" +
+            "Encryption=False\n" +
+            "Payload=00142500400000000f0e35a4e900eb49d20000007fffffff8ffff080fdfa1fa1007fff8000960fa0\n";
 
     @Before
     public void setUp() throws Exception {
-        //manager = new InfrastructureInstanceManager();
-        //registration = mock(InfrastructureRegistrationMessage.class);
     }
 
     @Test
     public void testCarmaV2xMessageParse() {
         CarmaV2xMessage test = new CarmaV2xMessage(sampleMessage.getBytes());
+        assert(test != null);
     }
 
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Resolves an error with the tokenizer in the CarmaV2xMessage class. Previously it was not aware of line breaks, causing it to incorrectly bundle tokens together and thus cause a parse failure for valid message.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new test case, CarmaV2XMessageTest has been created and passes now where it failed before with the prior logic.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.