### PR TITLE
Add logic to find start of AMF message

### DIFF
--- a/co-simulation/lib/mosaic-carma-utils/src/main/java/gov/dot/fhwa/saxton/CarmaV2xMessage.java
+++ b/co-simulation/lib/mosaic-carma-utils/src/main/java/gov/dot/fhwa/saxton/CarmaV2xMessage.java
@@ -123,7 +123,8 @@ public class CarmaV2xMessage {
      * @param buf A binary array containing the data sent from the CARMA Platform's ns3 adapter
      */
     private void parseV2xMessage(byte[] buf)  {
-        String msg = new String(buf, StandardCharsets.UTF_8);
+        String rawMsg = new String(buf, StandardCharsets.UTF_8);
+        String msg = rawMsg.substring(rawMsg.indexOf("Version"), rawMsg.length());
 
         // Modeled after Stackoverflow answer by user Eritrean: https://stackoverflow.com/users/5176992/eritrean
         // On Question: https://stackoverflow.com/questions/61029164/how-to-split-string-by-comma-and-newline-n-in-java
@@ -161,7 +162,7 @@ public class CarmaV2xMessage {
             } else if (msgParts[i].equals("Payload")) {
                 payload = msgParts[++i];
             } else {
-                throw new IllegalArgumentException("No such field in CarmaV2xMessage.");
+                throw new IllegalArgumentException("No such field in CarmaV2xMessage: " + msgParts[i]);
             }
         }
     }

--- a/co-simulation/lib/mosaic-carma-utils/src/test/java/gov/dot/fhwa/saxton/CarmaV2xMessageTest.java
+++ b/co-simulation/lib/mosaic-carma-utils/src/test/java/gov/dot/fhwa/saxton/CarmaV2xMessageTest.java
@@ -45,4 +45,11 @@ public class CarmaV2xMessageTest {
         assert(test != null);
     }
 
+    @Test
+    public void testCarmaV2xMessageParse2() {
+        String sampleMessage2 = "jaksldfjkl;asdfjkl;asdfjkalsdfjkdjjsdjdf" + sampleMessage;
+        CarmaV2xMessage test = new CarmaV2xMessage(sampleMessage.getBytes());
+        assert(test != null);
+    }
+
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Added logic to skip over any junk bytes at the start of the UDP packet to only process it from where the AMF message actually starts.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New unit test added to evaluate logic and passes

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.