### PR TITLE
Removed SUMO vehicle in Town04 and Town04_test scenario

### DIFF
--- a/co-simulation/bundle/src/assembly/resources/scenarios/Town04/sumo/Town04.rou.xml
+++ b/co-simulation/bundle/src/assembly/resources/scenarios/Town04/sumo/Town04.rou.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on 2023-03-26 13:56:24 by Eclipse SUMO netedit Version 1.15.0
+<!-- generated on 2023-05-23 13:36:19 by Eclipse SUMO netedit Version 1.16.0
 -->
 
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <!-- Routes -->
+    <route id="r_0" edges="-7 -8 -9 -10 -11 -12 -13 -14 -36 -37 -38 -39 33 47 44 39 38 37 36 35"/>
     <!-- Vehicles, persons and containers (sorted by depart) -->
-    <flow id="f_0" begin="0.00" from="51" to="-1" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_1" begin="0.00" from="52" to="15" via="16" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_2" begin="0.00" from="-15" to="-51" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_3" begin="0.00" from="-29" to="-17" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_4" begin="0.00" from="-15" to="-17" via="-16" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_5" begin="0.00" from="1" to="-52" via="0" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_6" begin="0.00" from="17" to="-1" via="-30" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_7" begin="0.00" from="51" to="29" via="30" end="3600.00" vehsPerHour="1800.00"/>
+    <vehicle id="v_0" depart="999.00" route="r_0"/>
 </routes>

--- a/co-simulation/bundle/src/assembly/resources/scenarios/Town04_test/sumo/Town04.rou.xml
+++ b/co-simulation/bundle/src/assembly/resources/scenarios/Town04_test/sumo/Town04.rou.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on 2023-03-26 13:56:24 by Eclipse SUMO netedit Version 1.15.0
+<!-- generated on 2023-05-23 13:36:19 by Eclipse SUMO netedit Version 1.16.0
 -->
 
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <!-- Routes -->
+    <route id="r_0" edges="-7 -8 -9 -10 -11 -12 -13 -14 -36 -37 -38 -39 33 47 44 39 38 37 36 35"/>
     <!-- Vehicles, persons and containers (sorted by depart) -->
-    <flow id="f_0" begin="0.00" from="51" to="-1" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_1" begin="0.00" from="52" to="15" via="16" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_2" begin="0.00" from="-15" to="-51" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_3" begin="0.00" from="-29" to="-17" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_4" begin="0.00" from="-15" to="-17" via="-16" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_5" begin="0.00" from="1" to="-52" via="0" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_6" begin="0.00" from="17" to="-1" via="-30" end="3600.00" vehsPerHour="1800.00"/>
-    <flow id="f_7" begin="0.00" from="51" to="29" via="30" end="3600.00" vehsPerHour="1800.00"/>
+    <vehicle id="v_0" depart="999.00" route="r_0"/>
 </routes>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

For the K900 test plan, it doesn't include the test of the scenario vehicle (SUMO generated vehicles). This PR is to remove  SUMO vehicles but left only one with depart time far away from the beginning which is necessary for SUMO to run. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.