### PR TITLE
Updated loglevel of rti/ns3/mosaic application to avoid simulation sl…

### DIFF
--- a/co-simulation/bundle/src/assembly/resources/etc/logback.xml
+++ b/co-simulation/bundle/src/assembly/resources/etc/logback.xml
@@ -144,34 +144,34 @@
             <logger name="MosaicStarter" additivity="false" level="TRACE">
                 <appender-ref ref="MosaicLog"/>
             </logger>
-            <logger name="org.eclipse.mosaic.rti" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.rti" additivity="false" level="INFO">
                 <appender-ref ref="STDOUT"/>
                 <appender-ref ref="MosaicLog"/>
             </logger>
-            <logger name="org.eclipse.mosaic.rti.time" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.rti.time" additivity="false" level="INFO">
                 <appender-ref ref="MosaicLog"/>
             </logger>
-            <logger name="org.eclipse.mosaic.lib" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.lib" additivity="false" level="INFO">
                 <appender-ref ref="MosaicLog"/>
             </logger>
 
-            <logger name="org.eclipse.mosaic.fed.application" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.fed.application" additivity="false" level="INFO">
                 <appender-ref ref="ApplicationLog"/>
             </logger>
-            <logger name="ApplicationLogDelegate" additivity="false" level="TRACE">
+            <logger name="ApplicationLogDelegate" additivity="false" level="INFO">
                 <appender-ref ref="ApplicationLogDelegation"/>
             </logger>
 
-            <logger name="org.eclipse.mosaic.fed.omnetpp" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.fed.omnetpp" additivity="false" level="INFO">
                 <appender-ref ref="CommunicationLog"/>
             </logger>
-            <logger name="org.eclipse.mosaic.fed.ns3" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.fed.ns3" additivity="false" level="INFO">
                 <appender-ref ref="CommunicationLog"/>
             </logger>
-            <logger name="org.eclipse.mosaic.fed.sns" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.fed.sns" additivity="false" level="INFO">
                 <appender-ref ref="CommunicationLog"/>
             </logger>
-            <logger name="org.eclipse.mosaic.fed.cell" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.fed.cell" additivity="false" level="INFO">
                 <appender-ref ref="CellLog"/>
             </logger>
 
@@ -209,7 +209,7 @@
                 <appender-ref ref="InfrastructureLog"/>
             </logger>
 
-            <logger name="org.eclipse.mosaic.fed.output" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.fed.output" additivity="false" level="INFO">
                 <appender-ref ref="MosaicLog"/>
             </logger>
 
@@ -217,20 +217,20 @@
                 <appender-ref ref="ActivityLog"/>
             </logger>
 
-            <logger name="org.eclipse.mosaic.fed.ns3.ambassador.Ns3AmbassadorOutput" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.fed.ns3.ambassador.Ns3AmbassadorOutput" additivity="false" level="INFO">
                 <appender-ref ref="CommunicationDetailsLog"/>
             </logger>
 
-            <logger name="org.eclipse.mosaic.fed.ns3.ambassador.Ns3AmbassadorError" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.fed.ns3.ambassador.Ns3AmbassadorError" additivity="false" level="INFO">
                 <appender-ref ref="CommunicationDetailsLog"/>
             </logger>
             
-            <logger name="org.eclipse.mosaic.fed.ns3.ambassador" additivity="false" level="TRACE">
+            <logger name="org.eclipse.mosaic.fed.ns3.ambassador" additivity="false" level="INFO">
                 <appender-ref ref="CommunicationDetailsLog"/>
             </logger>
             <!-- All other stuff, which was not logged by other loggers before goes
                 to stdout and MOSAIC.log -->
-            <root level="TRACE">
+            <root level="INFO">
                 <appender-ref ref="STDOUT"/>
                 <appender-ref ref="MosaicLog"/>
             </root>


### PR DESCRIPTION
…ow down and crash

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Excessive logging was causing substantial slow down and crash of carma-simulation starting around 80 mark of Town04 scenario. Reduced log level of Mosaic core application/ RTI/ NS3 Ambassador from trace to info
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Improve simulation performance and avoid simulation crashes
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
In AWS and on lab linux machines
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.